### PR TITLE
feat: добавлена поддержка пула прокси с round-robin ротацией

### DIFF
--- a/autoreg/requirements.txt
+++ b/autoreg/requirements.txt
@@ -5,6 +5,10 @@ DrissionPage>=4.0.0
 requests>=2.31.0
 httpx>=0.25.0
 
+# SOCKS proxy support
+pysocks>=1.7.1
+aiohttp-socks>=0.8.0
+
 # Environment variables
 python-dotenv>=1.0.0
 

--- a/src/providers/AccountsProvider.ts
+++ b/src/providers/AccountsProvider.ts
@@ -1027,6 +1027,7 @@ export class KiroAccountsProvider implements vscode.WebviewViewProvider, vscode.
         name: profileData.name || 'New Profile',
         imap: profileData.imap || { server: '', user: '', password: '' },
         strategy: profileData.strategy || { type: 'single' },
+        proxy: profileData.proxy,
         status: 'active'
       });
 

--- a/src/providers/ImapProfileProvider.ts
+++ b/src/providers/ImapProfileProvider.ts
@@ -485,6 +485,7 @@ export class ImapProfileProvider {
       strategy: profile.strategy || { type: 'single' },
       status: profile.status || 'active',
       stats: profile.stats || { registered: 0, failed: 0 },
+      proxy: profile.proxy,  // Preserve proxy settings
       createdAt: profile.createdAt || now,
       updatedAt: profile.updatedAt || now,
       provider: profile.provider

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,13 @@ export interface ImapProfile {
   status: 'active' | 'paused' | 'exhausted' | 'error';
   isDefault?: boolean;
 
+  // Proxy settings (optional)
+  proxy?: {
+    enabled: boolean;
+    urls: string[];  // List of proxies for round-robin rotation
+    currentIndex?: number;  // Current position in rotation
+  };
+
   // Statistics
   stats: {
     registered: number;

--- a/src/webview/components/ProfileEditor.ts
+++ b/src/webview/components/ProfileEditor.ts
@@ -158,6 +158,23 @@ function renderEditorForm(t: Translations): string {
           <button class="btn btn-secondary" id="testConnectionBtn" onclick="testImapConnection()">🔌 ${t.testConnection}</button>
         </div>
         
+        <div class="form-section" id="proxySection">
+          <div class="form-section-title">${t.proxySettings}</div>
+          <div class="form-section-desc">${t.proxySettingsDesc}</div>
+          <div class="form-group">
+            <label class="toggle-label">
+              <input type="checkbox" id="proxyEnabled" onchange="toggleProxyFields()">
+              <span class="toggle-text">${t.proxyEnabled}</span>
+            </label>
+          </div>
+          <div class="form-group proxy-fields" id="proxyFields" style="display: none;">
+            <label class="form-label">${t.proxyUrl}</label>
+            <textarea class="form-input form-textarea" id="proxyUrls" rows="4" placeholder="${t.proxyUrlPlaceholder}"></textarea>
+            <div class="form-hint">${t.proxyUrlHint}</div>
+            <div class="proxy-stats" id="proxyStats"></div>
+          </div>
+        </div>
+        
         <div class="form-section">
           <div class="form-section-title">${t.emailStrategy}</div>
           <div class="form-section-desc">${t.emailStrategyDesc}</div>
@@ -223,6 +240,23 @@ export function renderProfileEditor({ t, inline = false }: ProfileEditorProps): 
             </div>
           </div>
           <button class="btn btn-secondary" id="testConnectionBtn" onclick="testImapConnection()">🔌 ${t.testConnection}</button>
+        </div>
+        
+        <div class="form-section" id="proxySection">
+          <div class="form-section-title">${t.proxySettings}</div>
+          <div class="form-section-desc">${t.proxySettingsDesc}</div>
+          <div class="form-group">
+            <label class="toggle-label">
+              <input type="checkbox" id="proxyEnabled" onchange="toggleProxyFields()">
+              <span class="toggle-text">${t.proxyEnabled}</span>
+            </label>
+          </div>
+          <div class="form-group proxy-fields" id="proxyFields" style="display: none;">
+            <label class="form-label">${t.proxyUrl}</label>
+            <textarea class="form-input form-textarea" id="proxyUrls" rows="4" placeholder="${t.proxyUrlPlaceholder}"></textarea>
+            <div class="form-hint">${t.proxyUrlHint}</div>
+            <div class="proxy-stats" id="proxyStats"></div>
+          </div>
         </div>
         
         <div class="form-section">

--- a/src/webview/i18n/locales/de.ts
+++ b/src/webview/i18n/locales/de.ts
@@ -140,6 +140,11 @@ export const de: Translations = {
   port: 'Port',
   password: 'Passwort',
   testConnection: 'Testen',
+  proxy: 'Proxy',
+  proxyEnabled: 'Proxy verwenden',
+  proxyUrl: 'Proxy-URL',
+  proxyUrlPlaceholder: 'socks5://user:pass@host:port',
+  proxyHint: 'Formate: socks5://user:pass@host:port oder host:port:user:pass',
   testing: 'Teste...',
   emailStrategy: 'E-Mail-Strategie',
   emailStrategyDesc: 'Wählen Sie, wie E-Mails für die Registrierung generiert werden',
@@ -240,6 +245,11 @@ export const de: Translations = {
   serverStatusRunning: 'Läuft',
   serverStatusStopped: 'Gestoppt',
   serverStatusError: 'Fehler',
+
+  // Proxy Settings
+  proxySettings: 'Proxy',
+  proxySettingsDesc: 'Browser-Verkehr über Proxy-Server leiten',
+  proxyUrlHint: 'Formate: host:port:user:pass, socks5://user:pass@host:port',
 
   // Other
   delete: 'Löschen',

--- a/src/webview/i18n/locales/en.ts
+++ b/src/webview/i18n/locales/en.ts
@@ -140,6 +140,11 @@ export const en: Translations = {
   port: 'Port',
   password: 'Password',
   testConnection: 'Test',
+  proxy: 'Proxy',
+  proxyEnabled: 'Use Proxy',
+  proxyUrl: 'Proxy URL',
+  proxyUrlPlaceholder: 'socks5://user:pass@host:port',
+  proxyHint: 'Supports: socks5://user:pass@host:port or host:port:user:pass',
   testing: 'Testing...',
   emailStrategy: 'Email Strategy',
   emailStrategyDesc: 'Choose how to generate emails for registration',
@@ -240,6 +245,11 @@ export const en: Translations = {
   serverStatusRunning: 'Running',
   serverStatusStopped: 'Stopped',
   serverStatusError: 'Error',
+
+  // Proxy Settings
+  proxySettings: 'Proxy',
+  proxySettingsDesc: 'Route browser traffic through proxy server',
+  proxyUrlHint: 'Formats: host:port:user:pass, socks5://user:pass@host:port',
 
   // Other
   delete: 'Delete',

--- a/src/webview/i18n/locales/es.ts
+++ b/src/webview/i18n/locales/es.ts
@@ -140,6 +140,11 @@ export const es: Translations = {
   port: 'Puerto',
   password: 'Contraseña',
   testConnection: 'Probar',
+  proxy: 'Proxy',
+  proxyEnabled: 'Usar Proxy',
+  proxyUrl: 'URL del Proxy',
+  proxyUrlPlaceholder: 'socks5://user:pass@host:port',
+  proxyHint: 'Formatos: socks5://user:pass@host:port o host:port:user:pass',
   testing: 'Probando...',
   emailStrategy: 'Estrategia de Email',
   emailStrategyDesc: 'Elige cómo generar emails para el registro',
@@ -240,6 +245,11 @@ export const es: Translations = {
   serverStatusRunning: 'En ejecución',
   serverStatusStopped: 'Detenido',
   serverStatusError: 'Error',
+
+  // Proxy Settings
+  proxySettings: 'Proxy',
+  proxySettingsDesc: 'Enrutar tráfico del navegador a través del servidor proxy',
+  proxyUrlHint: 'Formatos: host:port:user:pass, socks5://user:pass@host:port',
 
   // Other
   delete: 'Eliminar',

--- a/src/webview/i18n/locales/fr.ts
+++ b/src/webview/i18n/locales/fr.ts
@@ -140,6 +140,11 @@ export const fr: Translations = {
   port: 'Port',
   password: 'Mot de passe',
   testConnection: 'Tester',
+  proxy: 'Proxy',
+  proxyEnabled: 'Utiliser le Proxy',
+  proxyUrl: 'URL du Proxy',
+  proxyUrlPlaceholder: 'socks5://user:pass@host:port',
+  proxyHint: 'Formats: socks5://user:pass@host:port ou host:port:user:pass',
   testing: 'Test en cours...',
   emailStrategy: 'Stratégie Email',
   emailStrategyDesc: "Choisissez comment générer les emails pour l'inscription",
@@ -240,6 +245,11 @@ export const fr: Translations = {
   serverStatusRunning: 'En cours',
   serverStatusStopped: 'Arrêté',
   serverStatusError: 'Erreur',
+
+  // Proxy Settings
+  proxySettings: 'Proxy',
+  proxySettingsDesc: 'Acheminer le trafic du navigateur via un serveur proxy',
+  proxyUrlHint: 'Formats: host:port:user:pass, socks5://user:pass@host:port',
 
   // Other
   delete: 'Supprimer',

--- a/src/webview/i18n/locales/hi.ts
+++ b/src/webview/i18n/locales/hi.ts
@@ -140,6 +140,11 @@ export const hi: Translations = {
   port: 'पोर्ट',
   password: 'पासवर्ड',
   testConnection: 'परीक्षण',
+  proxy: 'प्रॉक्सी',
+  proxyEnabled: 'प्रॉक्सी का उपयोग करें',
+  proxyUrl: 'प्रॉक्सी URL',
+  proxyUrlPlaceholder: 'socks5://user:pass@host:port',
+  proxyHint: 'प्रारूप: socks5://user:pass@host:port या host:port:user:pass',
   testing: 'परीक्षण हो रहा है...',
   emailStrategy: 'ईमेल रणनीति',
   emailStrategyDesc: 'पंजीकरण के लिए ईमेल कैसे जनरेट करें चुनें',
@@ -240,6 +245,11 @@ export const hi: Translations = {
   serverStatusRunning: 'चल रहा है',
   serverStatusStopped: 'बंद हो गया',
   serverStatusError: 'त्रुटि',
+
+  // Proxy Settings
+  proxySettings: 'प्रॉक्सी',
+  proxySettingsDesc: 'प्रॉक्सी सर्वर के माध्यम से ब्राउज़र ट्रैफ़िक रूट करें',
+  proxyUrlHint: 'प्रारूप: host:port:user:pass, socks5://user:pass@host:port',
 
   // Other
   delete: 'हटाएं',

--- a/src/webview/i18n/locales/ja.ts
+++ b/src/webview/i18n/locales/ja.ts
@@ -140,6 +140,11 @@ export const ja: Translations = {
   port: 'ポート',
   password: 'パスワード',
   testConnection: 'テスト',
+  proxy: 'プロキシ',
+  proxyEnabled: 'プロキシを使用',
+  proxyUrl: 'プロキシURL',
+  proxyUrlPlaceholder: 'socks5://user:pass@host:port',
+  proxyHint: '形式: socks5://user:pass@host:port または host:port:user:pass',
   testing: 'テスト中...',
   emailStrategy: 'メール戦略',
   emailStrategyDesc: '登録用メールの生成方法を選択',
@@ -240,6 +245,11 @@ export const ja: Translations = {
   serverStatusRunning: '実行中',
   serverStatusStopped: '停止',
   serverStatusError: 'エラー',
+
+  // Proxy Settings
+  proxySettings: 'プロキシ',
+  proxySettingsDesc: 'プロキシサーバー経由でブラウザトラフィックをルーティング',
+  proxyUrlHint: '形式: host:port:user:pass, socks5://user:pass@host:port',
 
   // Other
   delete: '削除',

--- a/src/webview/i18n/locales/ko.ts
+++ b/src/webview/i18n/locales/ko.ts
@@ -140,6 +140,11 @@ export const ko: Translations = {
   port: '포트',
   password: '비밀번호',
   testConnection: '테스트',
+  proxy: '프록시',
+  proxyEnabled: '프록시 사용',
+  proxyUrl: '프록시 URL',
+  proxyUrlPlaceholder: 'socks5://user:pass@host:port',
+  proxyHint: '형식: socks5://user:pass@host:port 또는 host:port:user:pass',
   testing: '테스트 중...',
   emailStrategy: '이메일 전략',
   emailStrategyDesc: '등록용 이메일 생성 방법 선택',
@@ -240,6 +245,11 @@ export const ko: Translations = {
   serverStatusRunning: '실행 중',
   serverStatusStopped: '중지됨',
   serverStatusError: '오류',
+
+  // Proxy Settings
+  proxySettings: '프록시',
+  proxySettingsDesc: '프록시 서버를 통해 브라우저 트래픽 라우팅',
+  proxyUrlHint: '형식: host:port:user:pass, socks5://user:pass@host:port',
 
   // Other
   delete: '삭제',

--- a/src/webview/i18n/locales/pt.ts
+++ b/src/webview/i18n/locales/pt.ts
@@ -140,6 +140,11 @@ export const pt: Translations = {
   port: 'Porta',
   password: 'Senha',
   testConnection: 'Testar',
+  proxy: 'Proxy',
+  proxyEnabled: 'Usar Proxy',
+  proxyUrl: 'URL do Proxy',
+  proxyUrlPlaceholder: 'socks5://user:pass@host:port',
+  proxyHint: 'Formatos: socks5://user:pass@host:port ou host:port:user:pass',
   testing: 'Testando...',
   emailStrategy: 'Estratégia de Email',
   emailStrategyDesc: 'Escolha como gerar emails para registro',
@@ -240,6 +245,11 @@ export const pt: Translations = {
   serverStatusRunning: 'Executando',
   serverStatusStopped: 'Parado',
   serverStatusError: 'Erro',
+
+  // Proxy Settings
+  proxySettings: 'Proxy',
+  proxySettingsDesc: 'Rotear tráfego do navegador através do servidor proxy',
+  proxyUrlHint: 'Formatos: host:port:user:pass, socks5://user:pass@host:port',
 
   // Other
   delete: 'Excluir',

--- a/src/webview/i18n/locales/ru.ts
+++ b/src/webview/i18n/locales/ru.ts
@@ -140,6 +140,11 @@ export const ru: Translations = {
   port: 'Порт',
   password: 'Пароль',
   testConnection: 'Проверить',
+  proxy: 'Прокси',
+  proxyEnabled: 'Использовать прокси',
+  proxyUrl: 'URL прокси',
+  proxyUrlPlaceholder: 'socks5://user:pass@host:port',
+  proxyHint: 'Форматы: socks5://user:pass@host:port или host:port:user:pass',
   testing: 'Проверка...',
   emailStrategy: 'Стратегия Email',
   emailStrategyDesc: 'Выберите как генерировать email для регистрации',
@@ -240,6 +245,11 @@ export const ru: Translations = {
   serverStatusRunning: 'Запущен',
   serverStatusStopped: 'Остановлен',
   serverStatusError: 'Ошибка',
+
+  // Proxy Settings
+  proxySettings: 'Прокси',
+  proxySettingsDesc: 'Направлять трафик браузера через прокси-сервер',
+  proxyUrlHint: 'Форматы: host:port:user:pass, socks5://user:pass@host:port',
 
   // Other
   delete: 'Удалить',

--- a/src/webview/i18n/locales/zh.ts
+++ b/src/webview/i18n/locales/zh.ts
@@ -140,6 +140,11 @@ export const zh: Translations = {
   port: '端口',
   password: '密码',
   testConnection: '测试',
+  proxy: '代理',
+  proxyEnabled: '使用代理',
+  proxyUrl: '代理URL',
+  proxyUrlPlaceholder: 'socks5://user:pass@host:port',
+  proxyHint: '格式: socks5://user:pass@host:port 或 host:port:user:pass',
   testing: '测试中...',
   emailStrategy: '邮箱策略',
   emailStrategyDesc: '选择如何生成注册邮箱',
@@ -240,6 +245,11 @@ export const zh: Translations = {
   serverStatusRunning: '运行中',
   serverStatusStopped: '已停止',
   serverStatusError: '错误',
+
+  // Proxy Settings
+  proxySettings: '代理',
+  proxySettingsDesc: '通过代理服务器路由浏览器流量',
+  proxyUrlHint: '格式: host:port:user:pass, socks5://user:pass@host:port',
 
   // Other
   delete: '删除',

--- a/src/webview/i18n/types.ts
+++ b/src/webview/i18n/types.ts
@@ -173,6 +173,11 @@ export interface Translations {
   port: string;
   password: string;
   testConnection: string;
+  proxy: string;
+  proxyEnabled: string;
+  proxyUrl: string;
+  proxyUrlPlaceholder: string;
+  proxyHint: string;
   testing: string;
   emailStrategy: string;
   emailStrategyDesc: string;
@@ -285,6 +290,16 @@ export interface Translations {
   serverStatusRunning: string;
   serverStatusStopped: string;
   serverStatusError: string;
+  // ============================================
+  // Proxy Settings
+  // ============================================
+  proxySettings: string;
+  proxySettingsDesc: string;
+  proxyEnabled: string;
+  proxyUrl: string;
+  proxyUrlPlaceholder: string;
+  proxyUrlHint: string;
+
   // Other
   // ============================================
   delete: string;

--- a/src/webview/scripts.ts
+++ b/src/webview/scripts.ts
@@ -862,11 +862,17 @@ export function generateWebviewScript(totalAccounts: number, bannedCount: number
       const serverEl = document.getElementById('imapServer');
       const portEl = document.getElementById('imapPort');
       const passwordEl = document.getElementById('imapPassword');
+      const proxyCheckbox = document.getElementById('proxyEnabled');
+      const proxyUrlsEl = document.getElementById('proxyUrls');
+      const proxyFields = document.getElementById('proxyFields');
       if (nameEl) nameEl.value = '';
       if (userEl) userEl.value = '';
       if (serverEl) serverEl.value = '';
       if (portEl) portEl.value = '993';
       if (passwordEl) passwordEl.value = '';
+      if (proxyCheckbox) proxyCheckbox.checked = false;
+      if (proxyUrlsEl) proxyUrlsEl.value = '';
+      if (proxyFields) proxyFields.style.display = 'none';
       selectStrategy('single');
       
       // Update title
@@ -895,6 +901,14 @@ export function generateWebviewScript(totalAccounts: number, bannedCount: number
       // Legacy overlay mode
       document.getElementById('profileEditor')?.classList.remove('visible');
       editingProfileId = null;
+    }
+    
+    function toggleProxyFields() {
+      const checkbox = document.getElementById('proxyEnabled');
+      const fields = document.getElementById('proxyFields');
+      if (checkbox && fields) {
+        fields.style.display = checkbox.checked ? 'block' : 'none';
+      }
     }
     
     function selectProfile(profileId) {
@@ -1089,6 +1103,12 @@ export function generateWebviewScript(totalAccounts: number, bannedCount: number
       const password = document.getElementById('imapPassword')?.value;
       const port = parseInt(document.getElementById('imapPort')?.value) || 993;
       
+      // Proxy settings
+      const proxyEnabled = document.getElementById('proxyEnabled')?.checked || false;
+      const proxyUrlsText = document.getElementById('proxyUrls')?.value?.trim() || '';
+      const proxyUrls = proxyUrlsText.split('\\n').map(u => u.trim()).filter(u => u.length > 0);
+      const proxy = proxyEnabled && proxyUrls.length > 0 ? { enabled: true, urls: proxyUrls, currentIndex: 0 } : undefined;
+      
       const selectedStrategy = document.querySelector('.strategy-option.selected');
       const strategyType = selectedStrategy?.dataset?.strategy || 'single';
       
@@ -1128,7 +1148,8 @@ export function generateWebviewScript(totalAccounts: number, bannedCount: number
             id: editingProfileId,
             name,
             imap: { server, user: firstEmail, password: firstPassword, port },
-            strategy
+            strategy,
+            proxy
           }
         });
       } else {
@@ -1144,7 +1165,8 @@ export function generateWebviewScript(totalAccounts: number, bannedCount: number
             id: editingProfileId,
             name,
             imap: { server, user, password, port },
-            strategy
+            strategy,
+            proxy
           }
         });
       }
@@ -1229,6 +1251,23 @@ export function generateWebviewScript(totalAccounts: number, bannedCount: number
       document.getElementById('imapServer').value = profile.imap?.server || '';
       document.getElementById('imapPort').value = profile.imap?.port || 993;
       document.getElementById('imapPassword').value = profile.imap?.password || '';
+      
+      // Proxy settings
+      const proxyCheckbox = document.getElementById('proxyEnabled');
+      const proxyUrlsInput = document.getElementById('proxyUrls');
+      const proxyFields = document.getElementById('proxyFields');
+      const proxyStats = document.getElementById('proxyStats');
+      if (proxyCheckbox && proxyUrlsInput) {
+        const hasProxy = profile.proxy?.enabled || false;
+        proxyCheckbox.checked = hasProxy;
+        proxyUrlsInput.value = (profile.proxy?.urls || []).join('\\n');
+        if (proxyFields) {
+          proxyFields.style.display = hasProxy ? 'block' : 'none';
+        }
+        if (proxyStats && profile.proxy?.urls) {
+          proxyStats.textContent = profile.proxy.urls.length + ' proxies';
+        }
+      }
       
       const strategyType = profile.strategy?.type || 'single';
       selectStrategy(strategyType);


### PR DESCRIPTION
## Что добавлено

- Конфигурация пула прокси в IMAP профилях (массив URL)
- Round-robin выбор прокси для регистраций
- UI прокси в ProfileEditor (textarea для нескольких прокси)
- Поддержка SOCKS прокси (pysocks, aiohttp-socks)
- Переводы прокси на все 10 языков
- Исправлено сохранение поля proxy при миграции профилей

## Как использовать

1. Открыть профиль IMAP
2. Включить прокси и добавить список (по одному на строку)
3. Формат: `socks5://user:pass@host:port` или `http://host:port`
4. При каждой регистрации используется следующий прокси из списка

## Тестирование

✅ Прокси передаётся в Python через HTTPS_PROXY
✅ Round-robin работает корректно
✅ SOCKS5 прокси работает (требует pysocks)