### PR TITLE
fix: use cross-platform path detection in KiroPatcherService

### DIFF
--- a/autoreg/services/kiro_patcher_service.py
+++ b/autoreg/services/kiro_patcher_service.py
@@ -76,13 +76,12 @@ class KiroPatcherService:
         if self._kiro_path:
             return self._kiro_path
         
-        # Windows default path
-        local_app_data = os.environ.get('LOCALAPPDATA', '')
-        if local_app_data:
-            path = Path(local_app_data) / 'Programs' / 'Kiro'
-            if path.exists():
-                self._kiro_path = path
-                return path
+        # Use cross-platform path detection from kiro_config
+        from autoreg.core.kiro_config import get_kiro_install_path
+        path = get_kiro_install_path()
+        if path:
+            self._kiro_path = path
+            return path
         
         return None
     


### PR DESCRIPTION
## Problem
`KiroPatcherService.kiro_install_path` only checked Windows paths (`LOCALAPPDATA`), causing `patch apply` to fail on Linux with "Kiro not installed" error even when Kiro is installed at `/usr/share/kiro`.

## Solution
Use `get_kiro_install_path()` from `kiro_config.py` which already supports cross-platform path detection:
- Windows: `%LOCALAPPDATA%/Programs/kiro`
- macOS: `/Applications/Kiro.app`
- Linux: `/usr/share/kiro`, `/opt/kiro`, `~/.local/share/kiro`

## Changes
- Modified `kiro_install_path` property in `kiro_patcher_service.py` to use the existing cross-platform detection function instead of Windows-only logic.

## Testing
Tested on Ubuntu with Kiro installed via `.deb` package at `/usr/share/kiro`. The patch command now works correctly.